### PR TITLE
Add Quick CLI to convert CTF to pprof

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ memtrace viewer, which lives at:
     https://github.com/janestreet/memtrace_viewer
 
 ## Installation
-These instructions are for using statmemprof with OCaml 5.3.0+trunk
+These instructions are for using statmemprof with OCaml 5.3.0
 
 ``` shell
 # Setup a new Blank switch
-opam switch create 5.3.0~alpha1 --no-install
-eval $(opam env --switch=5.3.0~alpha1 --set-switch)
+opam switch create 5.3.0 --no-install
+eval $(opam env --switch=5.3.0 --set-switch)
+opam install . --deps-only --with-test
 
 # Install dune
-opam install dune
+opam install dune domainslib
 ```
 
 Now we can get memory traces for programs, here is a multicore fibonacci program:

--- a/bin/convert.ml
+++ b/bin/convert.ml
@@ -1,0 +1,9 @@
+let convert input_file output_file =
+  Memtrace.Ctf_to_proto.convert_file input_file output_file
+
+let () =
+  if Array.length Sys.argv <> 3 then
+    Printf.fprintf stderr "Usage: %s <trace file> <protobuf file>\n" Sys.executable_name
+    else
+      convert Sys.argv.(1) Sys.argv.(2)
+

--- a/bin/dune
+++ b/bin/dune
@@ -1,10 +1,11 @@
 (executables
- (names dump_trace identify subsample hotspots flamegraph dump_profile)
+ (names dump_trace identify subsample hotspots flamegraph dump_profile convert)
  (public_names
   memtrace_dump_trace
-  memtrace_dump_profile
   memtrace_identify
   memtrace_subsample
   memtrace_hotspots
-  memtrace_flamegraph)
+  memtrace_flamegraph
+  memtrace_dump_profile
+  memtrace_convert)
  (libraries memtrace))

--- a/dune-project
+++ b/dune-project
@@ -14,4 +14,5 @@
  (synopsis "Streaming client for Memprof")
  (description "Generates compact traces of a program's memory use.")
  (depends
-  (ocaml (or (>= 5.3.0) (and (>= 4.11.0) (< 5.0))))))
+  (ocaml (or (>= 5.3.0) (and (>= 4.11.0) (< 5.0))))
+  pbrt))

--- a/memtrace.opam
+++ b/memtrace.opam
@@ -11,6 +11,7 @@ bug-reports: "https://github.com/janestreet/memtrace/issues"
 depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "5.3.0" | >= "4.11.0" & < "5.0"}
+  "pbrt"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/src/ctf_to_proto.mli
+++ b/src/ctf_to_proto.mli
@@ -5,10 +5,10 @@ val get_or_add_string : string -> string list ref -> int64
 val get_or_add_fnid : string -> string list ref -> int64 * bool
 
 val loc_to_int : Trace.Location_code.t -> int64
-val micro_to_nanoseconds : int64 -> int64 
+val micro_to_nanoseconds : int64 -> int64
 
 val update_locs : Trace.Reader.t -> Trace.Location_code.t array -> int -> Profile.function_ list ref -> Profile.location list ref -> string list ref -> int64 list
 
-val convert_events : string -> float -> float -> Profile.profile
-val convert_file : string -> string -> float -> float -> unit
+val convert_events : string -> float -> Profile.profile
+val convert_file : string -> string -> float -> unit
 

--- a/src/ctf_to_proto.mli
+++ b/src/ctf_to_proto.mli
@@ -9,6 +9,6 @@ val micro_to_nanoseconds : int64 -> int64
 
 val update_locs : Trace.Reader.t -> Trace.Location_code.t array -> int -> Profile.function_ list ref -> Profile.location list ref -> string list ref -> int64 list
 
-val convert_events : string -> float -> Profile.profile
-val convert_file : string -> string -> float -> unit
+val convert_events : string -> Profile.profile
+val convert_file : string -> string -> unit
 

--- a/src/memtrace.ml
+++ b/src/memtrace.ml
@@ -45,17 +45,17 @@ let start_tracing ~context ~sampling_rate ~filename =
 let stop_tracing t =
   Memprof_tracer.stop t
 
-let create_pb_file filename sample_rate time_end = Ctf_to_proto.convert_file filename (filename ^ ".pb") sample_rate time_end
+let create_pb_file filename = Ctf_to_proto.convert_file filename (filename ^ ".pb")
 
 
 let () =
-  at_exit ( 
-    fun () -> 
+  at_exit (
+    fun () ->
       begin
-        Option.iter stop_tracing (Memprof_tracer.active_tracer ()); 
-        create_pb_file !file !sample_rate (Unix.gettimeofday ())
+        Option.iter stop_tracing (Memprof_tracer.active_tracer ());
+        create_pb_file !file
       end
-  ) (* is this where timeofday should be called ? *) 
+  ) (* is this where timeofday should be called ? *)
 
 let default_sampling_rate = 1e-6
 

--- a/src/memtrace.ml
+++ b/src/memtrace.ml
@@ -47,7 +47,6 @@ let stop_tracing t =
 
 let create_pb_file filename = Ctf_to_proto.convert_file filename (filename ^ ".pb")
 
-
 let () =
   at_exit (
     fun () ->
@@ -94,3 +93,5 @@ module External = struct
   let free = Memprof_tracer.ext_free
 end
 module Geometric_sampler = Geometric_sampler
+
+module Ctf_to_proto = Ctf_to_proto

--- a/src/memtrace.mli
+++ b/src/memtrace.mli
@@ -29,7 +29,7 @@ val stop_tracing : tracer -> unit
 
 val default_sampling_rate : float
 
-val create_pb_file : string -> float -> float -> unit 
+val create_pb_file : string -> unit 
 
 (** Use the Trace module to read and write trace files *)
 module Trace = Trace

--- a/src/memtrace.mli
+++ b/src/memtrace.mli
@@ -29,7 +29,7 @@ val stop_tracing : tracer -> unit
 
 val default_sampling_rate : float
 
-val create_pb_file : string -> unit 
+val create_pb_file : string -> unit
 
 (** Use the Trace module to read and write trace files *)
 module Trace = Trace
@@ -56,3 +56,6 @@ end
 
 (** (For testing) *)
 module Geometric_sampler = Geometric_sampler
+
+(** Temporarily export CTF to Proto conversion module (For testing) *)
+module Ctf_to_proto = Ctf_to_proto


### PR DESCRIPTION
Plus various fixes along the way.

```
# Performs the conversion
$ dune exec -- memtrace_convert fib_par.ctf fib_par.pb

# Opens PProf's web UI with the file
$ ~/go/bin/pprof -http localhost:8080 fib_par.pb
```