### PR TITLE
Process memory maps for Linux and MacOS

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -1,5 +1,5 @@
 (executables
- (names dump_trace identify subsample hotspots flamegraph dump_profile convert)
+ (names dump_trace identify subsample hotspots flamegraph dump_profile convert self_memory_map)
  (public_names
   memtrace_dump_trace
   memtrace_identify
@@ -7,5 +7,6 @@
   memtrace_hotspots
   memtrace_flamegraph
   memtrace_dump_profile
-  memtrace_convert)
+  memtrace_convert
+  self_memory_map)
  (libraries memtrace))

--- a/dune-project
+++ b/dune-project
@@ -15,4 +15,5 @@
  (description "Generates compact traces of a program's memory use.")
  (depends
   (ocaml (or (>= 5.3.0) (and (>= 4.11.0) (< 5.0))))
-  pbrt))
+   pbrt
+   ctypes))

--- a/memtrace.opam
+++ b/memtrace.opam
@@ -12,6 +12,7 @@ depends: [
   "dune" {>= "2.3"}
   "ocaml" {>= "5.3.0" | >= "4.11.0" & < "5.0"}
   "pbrt"
+  "ctypes"
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/memtrace.opam
+++ b/memtrace.opam
@@ -29,3 +29,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/janestreet/memtrace.git"
+pin-depends: [
+  ["mach.dev" "git+https://github.com/tmcgilchrist/mach.git#main"]
+]

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,7 @@
  (public_name memtrace)
  (flags
   (:standard -w -27-32-69))           ; Ignore unused code while hacking
- (libraries unix threads pbrt ctypes))
+ (libraries unix threads pbrt ctypes mach))
 
 ;; Simplify the range of values used for Config.system
 ;; See https://github.com/ocaml/ocaml/pull/12405

--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,20 @@
 (library
  (name memtrace)
  (public_name memtrace)
- (libraries unix threads pbrt))
+ (flags
+  (:standard -w -27-32-69))           ; Ignore unused code while hacking
+ (libraries unix threads pbrt ctypes))
 
+;; Simplify the range of values used for Config.system
+;; See https://github.com/ocaml/ocaml/pull/12405
+(rule
+ (deps linux_memory_map.ml)
+ (target memory_map.ml)
+ (enabled_if (= %{system} "linux"))
+ (action (copy %{deps} %{target})))
+
+(rule
+ (deps macos_memory_map.ml)
+ (target memory_map.ml)
+ (enabled_if (= %{system} "macosx"))
+ (action (copy %{deps} %{target})))

--- a/src/linux_memory_map.ml
+++ b/src/linux_memory_map.ml
@@ -1,0 +1,60 @@
+open PosixTypes
+(** Read process [pid] memory maps.
+
+Opens /proc/<pid>/maps and reads each row in the file.
+Each row has the following fields:
+
+address           perms offset  dev   inode   pathname
+08048000-08056000 r-xp 00000000 03:0c 64593   /usr/sbin/GM
+
+where
+  - address: the starting and ending address of the region in the process's address space
+  - permissions: This describes how pages in the region can be accessed. There are four different permissions: read, write, execute, and shared. If read/write/execute are disabled, a - will appear instead of the r/w/x. If a region is not shared, it is private, so a p will appear instead of an s. If the process attempts to access memory in a way that is not permitted, a segmentation fault is generated. Permissions can be changed using the mprotect system call.
+  - offset: If the region was mapped from a file (using mmap), this is the offset in the file where the mapping begins. If the memory was not mapped from a file, it's just 0.
+  - device: the major and minor device number (in hex) if this region was mapped from a file.
+  - inode: the file number, if this region was mapped from a file.
+  - pathname the name of the file, if this region was mapped from a file. There are also special regions with names like [heap], [stack], or [vdso] virtual dynamic shared object.
+
+See https://stackoverflow.com/questions/1401359/understanding-linux-proc-pid-maps-or-proc-self-maps
+ *)
+
+type memory_map = {
+  address_start: int64;
+  address_end: int64;
+  perm_read: bool;
+  perm_write: bool;
+  perm_execute: bool;
+  perm_shared: bool;
+  offset: int64;
+  device_major: int;
+  device_minor: int;
+  inode: int64;
+  pathname: string;
+  }
+
+let mk_entry
+  address_start address_end pr pw px ps offset
+  device_major device_minor inode pathname =
+  { address_start; address_end; offset;
+    device_major; device_minor; inode;
+    pathname = String.trim pathname;
+    perm_read    = pr = 'r';
+    perm_write   = pw = 'w';
+    perm_execute = px = 'x';
+    perm_shared  = ps = 's';
+    }
+
+let scan_line ic =
+  Scanf.bscanf ic "%Lx-%Lx %c%c%c%c %Lx %x:%x %Ld%s@\n" mk_entry
+
+let rec scan_lines ic =
+  match scan_line ic with
+  | entry -> entry :: scan_lines ic
+  | exception End_of_file -> []
+
+let get_process_memory_maps (pid : Pid.t) =
+  let file = Printf.sprintf "/proc/%d/maps" (Pid.to_int pid) in
+  let ic = Scanf.Scanning.from_file file in
+  let lines = scan_lines ic in
+  Scanf.Scanning.close_in ic;
+  lines

--- a/src/macos_memory_map.ml
+++ b/src/macos_memory_map.ml
@@ -1,0 +1,30 @@
+open PosixTypes
+
+type memory_map = {
+  address_start: int64;
+  address_end: int64;
+  perm_read: bool;
+  perm_write: bool;
+  perm_execute: bool;
+  perm_shared: bool;
+  offset: int64;
+  device_major: int;
+  device_minor: int;
+  inode: int64;
+  pathname: string;
+  }
+
+let mk_entry
+  address_start address_end pr pw px ps offset
+  device_major device_minor inode pathname =
+  { address_start; address_end; offset;
+    device_major; device_minor; inode;
+    pathname = String.trim pathname;
+    perm_read    = pr = 'r';
+    perm_write   = pw = 'w';
+    perm_execute = px = 'x';
+    perm_shared  = ps = 's';
+    }
+
+let get_process_memory_maps (pid : Pid.t) =
+  []

--- a/src/macos_memory_map.ml
+++ b/src/macos_memory_map.ml
@@ -1,3 +1,4 @@
+open Ctypes
 open PosixTypes
 
 type memory_map = {
@@ -26,5 +27,71 @@ let mk_entry
     perm_shared  = ps = 's';
     }
 
+let get_memory_protection (prot : int32) =
+  let open Mach in
+  let r = if (not (Int32.equal (Int32.logand prot vm_prot_read) 0l)) then 'r' else '-' in
+  let w = if (not (Int32.equal (Int32.logand prot vm_prot_write) 0l)) then 'w' else '-' in
+  let x = if (not (Int32.equal (Int32.logand prot vm_prot_execute) 0l)) then 'x' else '-' in
+  (r, w, x)
+
+let vm_region_submap_info_count_64 =
+  let open Mach in
+  sizeof (vm_region_submap_info_data_64_t) / sizeof (natural_t)
+
+let vmmap task start_ end_ (depth : int) =
+  let open Mach in
+  let pid = allocate pid_t (PosixTypes.Pid.of_int 0) in
+  let _ = Mach.pid_for_task (!@task) pid in
+  let result = ref [] in
+  let start_ = ref start_ in
+  let break = ref false in
+  while (!break == false) do
+    let address = allocate mach_vm_address_t !start_ in
+    let size = allocate mach_vm_size_t Unsigned.UInt64.zero in
+    let depth0 = allocate vm_region_recurse_info_t (Int32.of_int depth) in
+    let info = allocate vm_region_submap_info_data_64_t (make vm_region_submap_info_data_64_t) in
+    let count = allocate mach_msg_type_number_t (Int32.of_int vm_region_submap_info_count_64) in
+    let kr = Mach.mach_vm_region_recurse (!@task) address size depth0
+      (to_voidp info |> from_voidp vm_region_recurse_info_t) count in
+
+    if (not (Int32.equal kr kern_success) || (!@address) > end_) then begin
+        (* No break statement in OCaml, we can make one with boolean ref  *)
+        break := true
+      end
+    else begin
+      let address_start = !@address in
+      let address_end = Unsigned.UInt64.add address_start !@size in
+      (* macOS has current permissions and max permissions as
+         info.protection and info.max_protection.
+         Here we simplify that to current permissions.
+       *)
+      let (pr, pw, px) = get_memory_protection (getf (!@info) protection) in
+      let ps = '-' in
+      let pathname = CArray.make char (4 + 4096) in
+      let _kr = Mach.proc_regionfilename !@pid !@address (to_voidp (CArray.start pathname)) (Unsigned.UInt32.of_int (4 + 4096)) in
+      let pathname_str = CArray.to_list pathname |> List.to_seq |> String.of_seq in
+      let offset = Unsigned.UInt64.zero in
+      let device_major = 0 in
+      let device_minor = 0 in
+      let inode = Unsigned.UInt64.zero in
+      let entry = mk_entry (Unsigned.UInt64.to_int64 address_start) (Unsigned.UInt64.to_int64 address_end) pr pw px ps (Unsigned.UInt64.to_int64 offset)
+        device_major device_minor (Unsigned.UInt64.to_int64 inode) (pathname_str) in
+      result := entry :: (!result);
+      start_ := Unsigned.UInt64.add !@address !@size
+    end
+  done;
+  !result
+
 let get_process_memory_maps (pid : Pid.t) =
-  []
+  let open Mach in
+  let depth = 2048 in
+  let self = mach_task_self () in
+  let pid = (PosixTypes.Pid.of_string Sys.argv.(1)) in
+  let task = allocate uint64_t Unsigned.UInt64.zero in
+  let kr = task_for_pid self pid task in
+  if (not (Int32.equal kr kern_success)) then (
+     Printf.printf "task_for_pid(%d) failed: %s\n" (Pid.to_int pid) (Mach.mach_error_string kr);
+     exit 1);
+  vmmap task (Unsigned.UInt64.zero) (Unsigned.UInt64.max_int) depth
+
+

--- a/src/macos_memory_map.ml
+++ b/src/macos_memory_map.ml
@@ -86,7 +86,6 @@ let get_process_memory_maps (pid : Pid.t) =
   let open Mach in
   let depth = 2048 in
   let self = mach_task_self () in
-  let pid = (PosixTypes.Pid.of_string Sys.argv.(1)) in
   let task = allocate uint64_t Unsigned.UInt64.zero in
   let kr = task_for_pid self pid task in
   if (not (Int32.equal kr kern_success)) then (

--- a/src/memory_map.mli
+++ b/src/memory_map.mli
@@ -1,0 +1,17 @@
+open PosixTypes
+
+type memory_map = {
+  address_start: int64;
+  address_end: int64;
+  perm_read: bool;
+  perm_write: bool;
+  perm_execute: bool;
+  perm_shared: bool;
+  offset: int64;
+  device_major: int;
+  device_minor: int;
+  inode: int64;
+  pathname: string;
+  }
+
+val get_process_memory_maps : Pid.t -> memory_map list

--- a/src/memtrace.ml
+++ b/src/memtrace.ml
@@ -102,3 +102,4 @@ end
 module Geometric_sampler = Geometric_sampler
 
 module Ctf_to_proto = Ctf_to_proto
+module Memory_map = Memory_map

--- a/src/memtrace.mli
+++ b/src/memtrace.mli
@@ -60,3 +60,5 @@ module Geometric_sampler = Geometric_sampler
 
 (** Temporarily export CTF to Proto conversion module (For testing) *)
 module Ctf_to_proto = Ctf_to_proto
+
+module Memory_map = Memory_map

--- a/src/proto.ml
+++ b/src/proto.ml
@@ -94,7 +94,7 @@ module Writer = struct
     Stack.push "major" s;
     Stack.push "external" s;
     Stack.push "space" s;
-    Stack.push "words" s;
+    Stack.push "words" s
 
   let[@inline] encode_nested f v t = 
     let old_start = Write.get_pos t.encoder in


### PR DESCRIPTION
Using `Unix.getpid ()` we can retrieve the runtime memory maps for the current process.
There is a demo program `self_memory_map` that prints out it's own memory maps.

Run it like so:
```
dune exec -- self_memory_map
```